### PR TITLE
Foot note - attach comment to the end of query

### DIFF
--- a/FluentPDO/CommonQuery.php
+++ b/FluentPDO/CommonQuery.php
@@ -49,6 +49,7 @@ abstract class CommonQuery extends BaseQuery {
 		$clause = FluentUtils::toUpperWords($clause);
 		if ($clause == 'GROUP') $clause = 'GROUP BY';
 		if ($clause == 'ORDER') $clause = 'ORDER BY';
+		if ($clause == 'FOOT NOTE') $clause = "\n--";
 		$statement = array_shift($parameters);
 		if (strpos($clause, 'JOIN') !== FALSE) {
 			return $this->addJoinStatements($clause, $statement, $parameters);

--- a/FluentPDO/SelectQuery.php
+++ b/FluentPDO/SelectQuery.php
@@ -28,7 +28,8 @@ class SelectQuery extends CommonQuery {
 			'HAVING' => ' AND ',
 			'ORDER BY' => ', ',
 			'LIMIT' => null,
-			'OFFSET' => null,
+            'OFFSET' => null,
+            "\n--" => "\n--",
 		);
 		parent::__construct($fpdo, $clauses);
 


### PR DESCRIPTION
When query is listed somewhere in slow log or similar query debugging
tool, there is usualy no info, where is query located in code. This foot
note allows you to attach all required info directly into the query.

Example:

```
$fpdo->from('hello')->footNote(__METHOD__.' at line '.__LINE__);
```

Result query:

```
SELECT hello.*
FROM hello
-- Foo::bar at line 123
```
