### PR TITLE
Added quotation marks for insert queries

### DIFF
--- a/FluentPDO/InsertQuery.php
+++ b/FluentPDO/InsertQuery.php
@@ -85,8 +85,15 @@ class InsertQuery extends BaseQuery {
 			$quoted = array_map(array($this, 'quote'), $rows);
 			$valuesArray[] = '(' . implode(', ', $quoted) . ')';
 		}
-		$columns = implode(', ', $this->columns);
+
+		$cols = array();
+		foreach ($this->columns as $column) {
+			$cols[] = '`'.$column.'`';
+		}
+
+		$columns = implode(', ', $cols);
 		$values = implode(', ', $valuesArray);
+
 		return " ($columns) VALUES $values";
 	}
 


### PR DESCRIPTION
The final query is now like
INSERT INTO tablename (`col1`, `col2`) VALUES ('val1', 'val2')

Reported in issue #49

Works as it should in MySQL, but I don't know if this will affect other
PDO drivers like SQLite or so.
