### PR TITLE
escape column names for INSERT statements

### DIFF
--- a/FluentPDO/InsertQuery.php
+++ b/FluentPDO/InsertQuery.php
@@ -85,9 +85,9 @@ class InsertQuery extends BaseQuery {
 			$quoted = array_map(array($this, 'quote'), $rows);
 			$valuesArray[] = '(' . implode(', ', $quoted) . ')';
 		}
-		$columns = implode(', ', $this->columns);
+		$columns = implode('`, `', $this->columns);
 		$values = implode(', ', $valuesArray);
-		return " ($columns) VALUES $values";
+		return " (`$columns`) VALUES $values";
 	}
 
 	protected function getClauseOnDuplicateKeyUpdate() {


### PR DESCRIPTION
If a reserved word is used as a column name, like `key`, the insert fails unless the backtick is used.
