### PR TITLE
Escaping column names

### DIFF
--- a/FluentPDO/CommonQuery.php
+++ b/FluentPDO/CommonQuery.php
@@ -46,8 +46,9 @@ abstract class CommonQuery extends BaseQuery {
 		if (count($args) == 1) {
 			return $this->addStatement('WHERE', $condition);
 		}
-		if (count($args) == 2 && preg_match('~^(NOT )?[a-z_:][a-z0-9_.:]*$~i', $condition)) {
+		if (count($args) == 2 && preg_match('~^(NOT )?[a-z_:`][a-z0-9_.:`]*$~i', $condition)) {
 			# condition is column only
+			$condition = preg_match("/`.*`/", $condition) ? $condition : sprintf("`%s`", $condition);
 			if (is_null($parameters)) {
 				return $this->addStatement('WHERE', "$condition is NULL");
 			} elseif (is_array($args[1])) {

--- a/FluentPDO/SelectQuery.php
+++ b/FluentPDO/SelectQuery.php
@@ -34,6 +34,7 @@ class SelectQuery extends CommonQuery implements Countable {
 		parent::__construct($fpdo, $clauses);
 
 		# initialize statements
+		$from = preg_match("/`.*`/", $from) ? $from : sprintf("`%s`", $from);
 		$fromParts = explode(' ', $from);
 		$this->fromTable = reset($fromParts);
 		$this->fromAlias = end($fromParts);


### PR DESCRIPTION
If column name is e.g. "group" it needs to be escaped to not match the mysql command group.

Checking if the column is already escaped, otherwise escape by adding `
