### PR TITLE
Added flag to convert types to native PHP data types

### DIFF
--- a/FluentPDO/FluentPDO.php
+++ b/FluentPDO/FluentPDO.php
@@ -35,6 +35,9 @@ class FluentPDO
     /** @var bool|callback */
     public $debug;
 
+    /** @var boolean */
+    public $convertTypes = false;
+
     /**
      * FluentPDO constructor.
      *

--- a/FluentPDO/FluentUtils.php
+++ b/FluentPDO/FluentUtils.php
@@ -37,4 +37,50 @@ class FluentUtils
         return $query;
     }
 
+    /**
+     * Converts columns from strings to types according to 
+     * PDOStatement::columnMeta
+     * http://stackoverflow.com/a/9952703/3006989
+     * 
+     * @param PDOStatement $st
+     * @param array $assoc returned by PDOStatement::fetch with PDO::FETCH_ASSOC
+     * @return copy of $assoc with matching type fields
+     */
+    public static function convertToNativeTypes(PDOStatement $statement, $rows)
+    {
+        for ($i = 0; $columnMeta = $statement->getColumnMeta($i); $i++)
+        {
+            $type = $columnMeta['native_type'];
+    
+            switch($type)
+            {
+                case 'DECIMAL':
+                case 'TINY':
+                case 'SHORT':
+                case 'LONG':
+                case 'LONGLONG':
+                case 'INT24':
+                        if(isset($rows[$columnMeta['name']])){
+                            $rows[$columnMeta['name']] = $rows[$columnMeta['name']] + 0;
+                        }else{
+                            if(is_array($rows) || $rows instanceof Traversable){
+                                foreach($rows as &$row){
+                                    if(isset($row[$columnMeta['name']])){
+                                        $row[$columnMeta['name']] = $row[$columnMeta['name']] + 0;
+                                    }
+                                }
+                            }                           
+                        }
+                    break;
+                case 'DATETIME':
+                case 'DATE':
+                case 'TIMESTAMP':
+                    // convert to date type?
+                    break;
+                // default: keep as string
+            }
+        }
+        return $rows;
+    }
+
 }

--- a/FluentPDO/SelectQuery.php
+++ b/FluentPDO/SelectQuery.php
@@ -106,7 +106,7 @@ class SelectQuery extends CommonQuery implements Countable
         $row = $s->fetch();
 
         if($this->convertTypes){
-            $row = $this->convertToNativeTypes($s,$row);
+            $row = FluentUtils::convertToNativeTypes($s,$row);
         }
 
         if ($row && $column != '') {
@@ -162,7 +162,7 @@ class SelectQuery extends CommonQuery implements Countable
         } else {
             if (($s = $this->execute()) !== false) {
                 if($this->convertTypes){
-                    return $this->convertToNativeTypes($s,$s->fetchAll());
+                    return FluentUtils::convertToNativeTypes($s,$s->fetchAll());
                 }else{
                     return $s->fetchAll();
                 }
@@ -170,52 +170,6 @@ class SelectQuery extends CommonQuery implements Countable
 
             return $s;
         }
-    }
-
-    /**
-     * Converts columns from strings to types according to 
-     * PDOStatement::columnMeta
-     * http://stackoverflow.com/a/9952703/3006989
-     * 
-     * @param PDOStatement $st
-     * @param array $assoc returned by PDOStatement::fetch with PDO::FETCH_ASSOC
-     * @return copy of $assoc with matching type fields
-     */
-    private function convertToNativeTypes(PDOStatement $statement, $rows)
-    {
-        for ($i = 0; $columnMeta = $statement->getColumnMeta($i); $i++)
-        {
-            $type = $columnMeta['native_type'];
-    
-            switch($type)
-            {
-                case 'DECIMAL':
-                case 'TINY':
-                case 'SHORT':
-                case 'LONG':
-                case 'LONGLONG':
-                case 'INT24':
-                        if(isset($rows[$columnMeta['name']])){
-                            $rows[$columnMeta['name']] = $rows[$columnMeta['name']] + 0;
-                        }else{
-                            if(is_array($rows) || $rows instanceof Traversable){
-                                foreach($rows as &$row){
-                                    if(isset($row[$columnMeta['name']])){
-                                        $row[$columnMeta['name']] = $row[$columnMeta['name']] + 0;
-                                    }
-                                }
-                            }                           
-                        }
-                    break;
-                case 'DATETIME':
-                case 'DATE':
-                case 'TIMESTAMP':
-                    // convert to date type?
-                    break;
-                // default: keep as string
-            }
-        }
-        return $rows;
     }
 
     /**


### PR DESCRIPTION
- When not using mysqlnd, by default PDO returns SQL numbers as PHP
strings.
- Even if using the newest PHP version, lot’s of hosting providers
don’t have mysqlnd installed (for example: hostgator has versions of
PHP that by default come with mysqlnd, but they removed it
intentionally)
- Added a `convertTypes` flag that when set to true, will convert any
SQL numbers from PHP strings to PHP numbers.
- Added in a way that doesn’t break older versions