### PR TITLE
allow where() to cope with empty arrays in the second argument

### DIFF
--- a/FluentPDO/CommonQuery.php
+++ b/FluentPDO/CommonQuery.php
@@ -73,6 +73,8 @@ abstract class CommonQuery extends BaseQuery
             // condition is column only
             if (is_null($parameters)) {
                 return $this->addStatement('WHERE', "$condition is NULL");
+            } elseif ($args[1] === []) {
+                return $this->addStatement('WHERE', 'FALSE');
             } elseif (is_array($args[1])) {
                 $in = $this->quote($args[1]);
 

--- a/FluentPDO/CommonQuery.php
+++ b/FluentPDO/CommonQuery.php
@@ -73,7 +73,7 @@ abstract class CommonQuery extends BaseQuery
             // condition is column only
             if (is_null($parameters)) {
                 return $this->addStatement('WHERE', "$condition is NULL");
-            } elseif ($args[1] === []) {
+            } elseif ($args[1] === array()) {
                 return $this->addStatement('WHERE', 'FALSE');
             } elseif (is_array($args[1])) {
                 $in = $this->quote($args[1]);


### PR DESCRIPTION
If I call `->where('field', [])` then currently Fluent generates the SQL `WHERE field IN ()` which looks reasonable but is unfortunately a syntax error.

Let's generate `WHERE FALSE` instead, which will overcome SQL's limitation and produce the correct results.
