### PR TITLE
Changed defined() into is_resource()

### DIFF
--- a/FluentPDO/BaseQuery.php
+++ b/FluentPDO/BaseQuery.php
@@ -172,7 +172,7 @@ abstract class BaseQuery implements IteratorAggregate
                 $time = sprintf('%0.3f', $this->time * 1000) . ' ms';
                 $rows = ($this->result) ? $this->result->rowCount() : 0;
                 $finalString = "# $backtrace[file]:$backtrace[line] ($time; rows = $rows)\n$debug\n\n";
-                if (defined(STDERR)) { // if STDERR is set, send there, otherwise just output the string
+                if (is_resource(STDERR)) { // if STDERR is set, send there, otherwise just output the string
                     fwrite(STDERR, $finalString);
                 }
                 else {


### PR DESCRIPTION
Function defined() expects parameter to be string.