### PR TITLE
Add query representation.

### DIFF
--- a/FluentPDO/BaseQuery.php
+++ b/FluentPDO/BaseQuery.php
@@ -37,6 +37,16 @@ abstract class BaseQuery implements IteratorAggregate
     }
 
     /**
+     * Return formatted query when request class representation
+     * ie: echo $query
+     *
+     * @return string - formatted query
+     */
+    public function __toString() {
+        return $this->getQuery();
+    }
+
+    /**
      * Initialize statement and parameter clauses.
      */
     private function initClauses() {


### PR DESCRIPTION
This way we can use `echo $query` without any php exception.