### PR TITLE
Added 'DOUBLE' and 'FLOAT' to PHP data type conversions

### DIFF
--- a/FluentPDO/FluentUtils.php
+++ b/FluentPDO/FluentUtils.php
@@ -55,6 +55,7 @@ class FluentUtils
             switch($type)
             {
                 case 'DECIMAL':
+                case 'NEWDECIMAL':
                 case 'FLOAT':
                 case 'DOUBLE':
                 case 'TINY':

--- a/FluentPDO/FluentUtils.php
+++ b/FluentPDO/FluentUtils.php
@@ -55,6 +55,8 @@ class FluentUtils
             switch($type)
             {
                 case 'DECIMAL':
+                case 'FLOAT':
+                case 'DOUBLE':
                 case 'TINY':
                 case 'SHORT':
                 case 'LONG':


### PR DESCRIPTION
I found that my FLOAT and DOUBLE columns in MySQL were not being converted to PHP native types when the convertTypes flag was set to true. Adding 'FLOAT' and 'DOUBLE' to the switch statement fixed this issue.