### PR TITLE
Fixes return type in where() method doc for correct IDE autocompletion

### DIFF
--- a/src/Queries/Common.php
+++ b/src/Queries/Common.php
@@ -50,7 +50,7 @@ abstract class Common extends Base
      * @param string $condition  possibly containing ? or :name (PDO syntax)
      * @param mixed  $parameters array or a scalar value
      *
-     * @return Common
+     * @return $this
      */
     public function where($condition, $parameters = array()) {
         if ($condition === null) {


### PR DESCRIPTION
In the where() method in class Common, changes the doc @return type from Common to $this. Actual behavior causes modern IDEs such as PHPStorm to loose correct autocomplete after using the where() method, changing the signature of the query object to 'Common' and issuing warnings on chained methods such as orderBy() and even execute() and fetchAll().