### PR TITLE
Check whether statement is countable in BaseQuery::clauseNotEmpty()

### DIFF
--- a/FluentPDO/BaseQuery.php
+++ b/FluentPDO/BaseQuery.php
@@ -289,7 +289,10 @@ abstract class BaseQuery implements IteratorAggregate
      * @return bool
      */
     private function clauseNotEmpty($clause) {
-        if ($this->clauses[$clause]) {
+        if (
+            (is_array($this->statements[$clause]) || $this->statements[$clause] instanceof \Countable) &&
+            $this->clauses[$clause]
+        ) {
             return (boolean)count($this->statements[$clause]);
         } else {
             return (boolean)$this->statements[$clause];


### PR DESCRIPTION
Closes #227 and #238. Backports functionality from Utilities::isCountable() in the 2.x branch to make 1.x compatible with PHP 7.2.

There was a typo in the pull request linked to in #238, causing the CI checks to fail. This PR fixes that issue.