### PR TITLE
Add executeWithoutId() method to InsertQuery (as in v2.x)

### DIFF
--- a/FluentPDO/InsertQuery.php
+++ b/FluentPDO/InsertQuery.php
@@ -40,12 +40,29 @@ class InsertQuery extends BaseQuery
      * 
      * @param mixed $sequence
      *
-     * @return integer last inserted id or false
+     * @return int|bool - Last inserted primary key
      */
     public function execute($sequence = null) {
         $result = parent::execute();
         if ($result) {
             return $this->getPDO()->lastInsertId($sequence);
+        }
+
+        return false;
+    }
+
+    /**
+     * @param null $sequence
+     *
+     * @throws Exception
+     *
+     * @return bool
+     */
+    public function executeWithoutId($sequence = null) {
+        $result = parent::execute();
+
+        if ($result) {
+            return true;
         }
 
         return false;


### PR DESCRIPTION
Hi,

As fixed in v2.x, it's really useful to have executeWithoutId() method on InsertQuery in v1.x. i just apply the patch propose in https://github.com/envms/fluentpdo/pull/275 on legacy branch.

Thank for this great library,

Regards