### PR TITLE
Fix - Fatal error:  Uncaught TypeError

### DIFF
--- a/src/Queries/Base.php
+++ b/src/Queries/Base.php
@@ -23,7 +23,7 @@ abstract class Base implements IteratorAggregate
     /** @var Query */
     protected $fluent;
 
-    /** @var PDOStatement */
+    /** @var PDOStatement|null|bool */
     protected $result;
 
     /** @var array - definition clauses */
@@ -216,9 +216,9 @@ abstract class Base implements IteratorAggregate
     /**
      * Get PDOStatement result
      *
-     * @return ?PDOStatement
+     * @return PDOStatement|null|bool
      */
-    public function getResult(): ?PDOStatement
+    public function getResult()
     {
         return $this->result;
     }


### PR DESCRIPTION
$result in real can be boolean so this will fix Fatal error:  Uncaught TypeError: Return value of Envms\FluentPDO\Queries\Base::getResult() must be an instance of PDOStatement or null, bool returned