### PR TITLE
Pull

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "gillsonkell/fluentpdo",
+	"name": "envms/fluentpdo",
 	"description": "FluentPDO is a quick and light PHP library for rapid query building. It features a smart join builder, which automatically creates table joins.",
 	"keywords": ["db", "database", "dbal", "pdo", "fluent", "query", "builder", "mysql", "oracle"],
 	"homepage": "https://github.com/envms/fluentpdo",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "envms/fluentpdo",
+	"name": "gillsonkell/fluentpdo",
 	"description": "FluentPDO is a quick and light PHP library for rapid query building. It features a smart join builder, which automatically creates table joins.",
 	"keywords": ["db", "database", "dbal", "pdo", "fluent", "query", "builder", "mysql", "oracle"],
 	"homepage": "https://github.com/envms/fluentpdo",

--- a/src/Queries/Common.php
+++ b/src/Queries/Common.php
@@ -359,6 +359,11 @@ abstract class Common extends Base
         // don't rewrite table from other databases
         foreach ($this->joins as $join) {
             if (strpos($join, '.') !== false && strpos($statement, $join) === 0) {
+                // rebuild the where statement
+                if ($separator !== null) {
+                    $statement = [$separator, $statement];
+                }
+                
                 return $statement;
             }
         }

--- a/tests/Queries/CommonTest.php
+++ b/tests/Queries/CommonTest.php
@@ -206,9 +206,9 @@ class CommonTest extends TestCase
 
     public function testFromOtherDB()
     {
-        $queryPrint = $this->fluent->from('db2.user')->order('db2.user.name')->getQuery(false);
+        $queryPrint = $this->fluent->from('db2.user')->where('db2.user.name', 'name')->order('db2.user.name')->getQuery(false);
 
-        self::assertEquals('SELECT db2.user.* FROM db2.user ORDER BY db2.user.name', $queryPrint);
+        self::assertEquals('SELECT db2.user.* FROM db2.user WHERE db2.user.name = ? ORDER BY db2.user.name', $queryPrint);
     }
 
     public function testJoinTableWithUsing()


### PR DESCRIPTION
Fix bug with applying a `where()` and specifying the schema. For example, this was not working as expected before:
```
$fluent->from('db2.user')->where('db2.user.name', 'name');
```