### PR TITLE
Use PDO::ATTR_DEFAULT_FETCH_MODE instead of PDO::FETCH_DEFAULT for PHP version lower than 8.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "envms/fluentpdo",
+	"name": "bosse-online/fluentpdo",
 	"description": "FluentPDO is a quick and light PHP library for rapid query building. It features a smart join builder, which automatically creates table joins.",
 	"keywords": ["db", "database", "dbal", "pdo", "fluent", "query", "builder", "mysql", "oracle"],
 	"homepage": "https://github.com/envms/fluentpdo",

--- a/src/Queries/Base.php
+++ b/src/Queries/Base.php
@@ -50,7 +50,14 @@ abstract class Base implements IteratorAggregate
      */
     protected function __construct(Query $fluent, $clauses)
     {
-        $this->currentFetchMode = defined('PDO::FETCH_DEFAULT') ? PDO::FETCH_DEFAULT : PDO::FETCH_BOTH;
+        if (defined('PDO::FETCH_DEFAULT)')) {
+            $this->currentFetchMode = $fluent->getPdo()->getAttribute(PDO::FETCH_DEFAULT);
+        } elseif (defined('PDO::ATTR_DEFAULT_FETCH_MODE)')) {
+            $this->currentFetchMode = $fluent->getPdo()->getAttribute(PDO::ATTR_DEFAULT_FETCH_MODE);
+        } else {
+            $this->currentFetchMode = $fluent->getPdo()->getAttribute(PDO::FETCH_BOTH);
+        }
+        
         $this->fluent = $fluent;
         $this->clauses = $clauses;
         $this->result = null;


### PR DESCRIPTION
PDO::FETCH_DEFAULT constant only exists in PHP 8 or higher. So check if PDO::ATTR_DEFAULT_FETCH_MODE is defined, too. Use the current PDO instance to allow changes via the PDO options.