### PR TITLE
Use ATTR_DEFAULT_FETCH_MODE on lower PHP versions.

### DIFF
--- a/src/Queries/Base.php
+++ b/src/Queries/Base.php
@@ -49,13 +49,13 @@ abstract class Base implements IteratorAggregate
      * @param       $clauses
      */
     protected function __construct(Query $fluent, $clauses)
-    {
-        if (defined('PDO::FETCH_DEFAULT)')) {
+    {        
+        if (defined('PDO::FETCH_DEFAULT')) {
             $this->currentFetchMode = $fluent->getPdo()->getAttribute(PDO::FETCH_DEFAULT);
-        } elseif (defined('PDO::ATTR_DEFAULT_FETCH_MODE)')) {
+        } elseif (defined('PDO::ATTR_DEFAULT_FETCH_MODE')) {
             $this->currentFetchMode = $fluent->getPdo()->getAttribute(PDO::ATTR_DEFAULT_FETCH_MODE);
         } else {
-            $this->currentFetchMode = $fluent->getPdo()->getAttribute(PDO::FETCH_BOTH);
+            $this->currentFetchMode = PDO::FETCH_BOTH;
         }
         
         $this->fluent = $fluent;

--- a/src/Queries/Base.php
+++ b/src/Queries/Base.php
@@ -50,7 +50,14 @@ abstract class Base implements IteratorAggregate
      */
     protected function __construct(Query $fluent, $clauses)
     {
-        $this->currentFetchMode = defined('PDO::FETCH_DEFAULT') ? PDO::FETCH_DEFAULT : PDO::FETCH_BOTH;
+        if (defined('PDO::FETCH_DEFAULT)')) {
+            $this->currentFetchMode = $fluent->getPdo()->getAttribute(PDO::FETCH_DEFAULT);
+        } elseif (defined('PDO::ATTR_DEFAULT_FETCH_MODE)')) {
+            $this->currentFetchMode = $fluent->getPdo()->getAttribute(PDO::ATTR_DEFAULT_FETCH_MODE);
+        } else {
+            $this->currentFetchMode = $fluent->getPdo()->getAttribute(PDO::FETCH_BOTH);
+        }
+        
         $this->fluent = $fluent;
         $this->clauses = $clauses;
         $this->result = null;

--- a/src/Queries/Base.php
+++ b/src/Queries/Base.php
@@ -51,9 +51,9 @@ abstract class Base implements IteratorAggregate
     protected function __construct(Query $fluent, $clauses)
     {        
         if (defined('PDO::FETCH_DEFAULT')) {
-            $this->currentFetchMode = $fluent->getPdo()->getAttribute(PDO::FETCH_DEFAULT);
+            $this->currentFetchMode = $fluent->getPdo()->getAttribute(PDO::FETCH_DEFAULT) ?? PDO::FETCH_DEFAULT;
         } elseif (defined('PDO::ATTR_DEFAULT_FETCH_MODE')) {
-            $this->currentFetchMode = $fluent->getPdo()->getAttribute(PDO::ATTR_DEFAULT_FETCH_MODE);
+            $this->currentFetchMode = $fluent->getPdo()->getAttribute(PDO::ATTR_DEFAULT_FETCH_MODE) ?? PDO::ATTR_DEFAULT_FETCH_MODE;
         } else {
             $this->currentFetchMode = PDO::FETCH_BOTH;
         }

--- a/src/Queries/Common.php
+++ b/src/Queries/Common.php
@@ -49,7 +49,7 @@ abstract class Common extends Base
     protected $joins = [];
 
     /** @var bool - Disable adding undefined joins to query? */
-    protected $isSmartJoinEnabled = true;
+    protected $isSmartJoinEnabled = false;
 
     /**
      * @param string $name


### PR DESCRIPTION
PDO::FETCH_DEFAULT constant only exists in PHP 8 or higher. So check if PDO::ATTR_DEFAULT_FETCH_MODE is defined, too. Use the current PDO instance to allow changes via the PDO options.